### PR TITLE
Remove tomoki1207.pdf as lhl2617.vslilypond now bundles a LilyPond PDF Viewer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,8 +11,7 @@
     ],
     // Add the IDs of extensions you want installed when the container is created.
     "extensions": [
-        "lhl2617.vslilypond",
-        "tomoki1207.pdf"
+        "lhl2617.vslilypond"
     ],
     // Connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
     "remoteUser": "vscode"


### PR DESCRIPTION
[v1.6.0](https://github.com/lhl2617/VSLilyPond/blob/master/CHANGELOG.md#160) of lhl2617.vslilypond now bundles a LilyPond-compatible PDF viewer (capable of point and click). `tomoki1207.pdf` is thus no longer required.