### PR TITLE
Remove python-ly installation as formatter now bundles a static binary

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,9 +13,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y --no-install-recommends install sudo git vim timidity fluid-soundfont-gm fluid-soundfont-gs \
     && rm -rf /var/lib/apt/lists/*
 
-# https://github.com/lhl2617/VSLilyPond/blob/master/docs/INSTALL.md#python-ly-setup-guide-required-for-formatting
-RUN python -m pip install python-ly
-
 RUN groupadd --gid "${USER_GID}" "${USERNAME}"
 RUN useradd -s /bin/bash --uid "${USER_UID}" --gid "${USER_GID}" --groups sudo --create-home "${USERNAME}"
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers


### PR DESCRIPTION
[v0.2.0](https://github.com/lhl2617/VSLilyPond-formatter) of lhl2617.lilypond-formatter now bundles a static binary for `python-ly`.

Tested on the devcontainer:
![image](https://user-images.githubusercontent.com/33488131/118195786-c83a3b00-b443-11eb-8589-f99455e90c3b.png)
